### PR TITLE
Fix missing Microsoft.Bcl.AsyncInterfaces for ServiceCollection project in NetsStandard 2.0

### DIFF
--- a/src/SimpleInjector.Integration.AspNetCore/SimpleInjector.Integration.AspNetCore.csproj
+++ b/src/SimpleInjector.Integration.AspNetCore/SimpleInjector.Integration.AspNetCore.csproj
@@ -33,7 +33,10 @@
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.0.0" />
     <PackageReference Include="SimpleInjector" Version="5.1.0" />
-    <PackageReference Include="SimpleInjector.Integration.ServiceCollection" Version="5.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SimpleInjector.Integration.ServiceCollection\SimpleInjector.Integration.ServiceCollection.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">

--- a/src/SimpleInjector.Integration.ServiceCollection/SimpleInjector.Integration.ServiceCollection.csproj
+++ b/src/SimpleInjector.Integration.ServiceCollection/SimpleInjector.Integration.ServiceCollection.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>
       Integrates Simple Injector with applications that require the use of IServiceCollection for registration of framework components.
@@ -9,7 +9,7 @@
     <PackageReleaseNotes>https://github.com/simpleinjector/SimpleInjector.Integration.AspNetCore/releases/tag/5.0.0</PackageReleaseNotes>
     <AssemblyVersion>5.0.0.0</AssemblyVersion>
     <Authors>Simple Injector Contributors</Authors>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>SimpleInjector.Integration.ServiceCollection</AssemblyName>
@@ -36,7 +36,11 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
-    <PackageReference Include="SimpleInjector" Version="5.0.0" />
+    <PackageReference Include="SimpleInjector" Version="5.1.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.1.0" />	
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Hi,

After updating SimpleInjector.Integration.AspNetCore.Mvc.Core to the latest version (5.1.1), my net 5.0 project fail to start.
I found that the root cause was that the package Microsoft.Bcl.AsyncInterfaces has been removed from SimpleInjector.Integration.AspNetCore project dependencies.
The problem is that the only target of this project is NetStandard 2.0, so I added a NetStandard 2.1 target and reintroduce the Microsoft.Bcl.AsyncInterfaces for the NetStandard 2.0 target.
I built the packages on my local machine for testing and the modification fix the issue.